### PR TITLE
chore(bootstrap): update GitHub repository list across environments

### DIFF
--- a/bootstrap/environments/dev.tfvars
+++ b/bootstrap/environments/dev.tfvars
@@ -6,11 +6,11 @@ location = "westus3"
 github_owner = "EdgeOpsTech"
 github_repo = [
   "terraform-azure-ops",
-  "kv-rbac-setup",
   "super-webapp",
   "azure-vm-setup",
   "edgeops-sub-mgmt",
-  "edgeops-keyvault-module"
+  "edgeops-keyvault-module",
+  "edgeops-automation-utils"
 ]
 
 branches     = ["main", "dev", "feature/*"]

--- a/bootstrap/environments/prod.tfvars
+++ b/bootstrap/environments/prod.tfvars
@@ -6,12 +6,13 @@ location = "westus3"
 github_owner = "EdgeOpsTech"
 github_repo = [
   "terraform-azure-ops",
-  "kv-rbac-setup",
   "super-webapp",
   "azure-vm-setup",
   "edgeops-sub-mgmt",
-  "edgeops-keyvault-module"
+  "edgeops-keyvault-module",
+  "edgeops-automation-utils"
 ]
+
 
 branches     = ["main", "dev", "release/*", "feature/*"]
 environments = ["dev", "test", "stage", "prod"]

--- a/bootstrap/environments/stage.tfvars
+++ b/bootstrap/environments/stage.tfvars
@@ -6,12 +6,13 @@ location = "westus3"
 github_owner = "EdgeOpsTech"
 github_repo = [
   "terraform-azure-ops",
-  "kv-rbac-setup",
   "super-webapp",
   "azure-vm-setup",
   "edgeops-sub-mgmt",
-  "edgeops-keyvault-module"
+  "edgeops-keyvault-module",
+  "edgeops-automation-utils"
 ]
+
 
 branches     = ["main", "dev", "release/*", "feature/*"]
 environments = ["dev", "test", "stage"]

--- a/bootstrap/environments/test.tfvars
+++ b/bootstrap/environments/test.tfvars
@@ -6,12 +6,13 @@ location = "westus3"
 github_owner = "EdgeOpsTech"
 github_repo = [
   "terraform-azure-ops",
-  "kv-rbac-setup",
   "super-webapp",
   "azure-vm-setup",
   "edgeops-sub-mgmt",
-  "edgeops-keyvault-module"
+  "edgeops-keyvault-module",
+  "edgeops-automation-utils"
 ]
+
 
 branches     = ["main", "dev", "feature/*"]
 environments = ["dev", "test"]


### PR DESCRIPTION
- Remove 'kv-rbac-setup' from GitHub repository configuration
- Add 'edgeops-automation-utils' to GitHub repository list
- Apply changes consistently across dev, test, stage, and prod environments

This update reflects changes in the repository structure, replacing the deprecated kv-rbac-setup with the new edgeops-automation-utils repository for bootstrap operations.